### PR TITLE
update last data explicitly

### DIFF
--- a/contracts/services/rebalancer/src/rebalance.rs
+++ b/contracts/services/rebalancer/src/rebalance.rs
@@ -270,8 +270,7 @@ pub fn do_rebalance(
             .iter()
             .find(|th| th.target.denom == target.denom)
         {
-            target.last_i = target_helper.target.last_i;
-            target.last_input = target_helper.target.last_input;
+            target.update_last(&target_helper.target);
         }
     }
 

--- a/packages/valence-package/src/services/rebalancer.rs
+++ b/packages/valence-package/src/services/rebalancer.rs
@@ -244,6 +244,14 @@ pub struct ParsedTarget {
     pub last_i: SignedDecimal,
 }
 
+impl ParsedTarget {
+    /// Update current target from helper,
+    pub fn update_last(&mut self, other: &ParsedTarget) {
+        self.last_input = other.last_input;
+        self.last_i = other.last_i;
+    }
+}
+
 impl From<Target> for ParsedTarget {
     fn from(value: Target) -> Self {
         ParsedTarget {


### PR DESCRIPTION
I don't think this covers #73 completely, but implementing the full solution would take a lot of modification to the code, and I don't think we need it right now.

As a temporary solution to the actual problem in #73, we have a `update_last` function that only update the fields that we want to update from helper, it basically hides the fact we update the target directly, and makes it a little better in catching that we only need to update certain fields instead of the whole target struct.